### PR TITLE
Add Nations plugin scaffold and build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Ignore Maven build output
+nations/target/
 living/target/
 # Ignore IDE files
 *.iml

--- a/compile.sh
+++ b/compile.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 set -e
 
-# Script to build the Living plugin on Debian based systems.
-# It installs required dependencies (OpenJDK and Maven) and
-# then compiles the plugin using Maven.
+# Script to build a plugin on Debian based systems.
+# Usage: ./compile.sh [plugin-directory]
+# If no directory is provided, it defaults to 'nations'.
+
+PLUGIN_DIR="${1:-nations}"
 
 if ! command -v javac >/dev/null 2>&1; then
     echo "Installing OpenJDK 21..."
@@ -17,8 +19,8 @@ if ! command -v mvn >/dev/null 2>&1; then
     sudo apt-get install -y maven
 fi
 
-cd "$(dirname "$0")/living"
+cd "$(dirname "$0")/${PLUGIN_DIR}"
 
 mvn -B package
 
-echo "Build completed. The plugin jar can be found in living/target."
+echo "Build completed. The plugin jar can be found in ${PLUGIN_DIR}/target."

--- a/nations/README.md
+++ b/nations/README.md
@@ -1,0 +1,7 @@
+# Nations Plugin
+
+This plugin introduces political and diplomatic gameplay to a Purpur server. Players can form nations, claim territory and engage in alliances or wars.
+
+## Building
+
+Run `../compile.sh nations` from the repository root to build the plugin. The compiled jar will be placed in `target/`.

--- a/nations/pom.xml
+++ b/nations/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>nations</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Nations</name>
+  <description>Political and diplomatic meta-game plugin.</description>
+
+  <properties>
+    <java.version>21</java.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>papermc</id>
+      <url>https://repo.papermc.io/repository/maven-public/</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.papermc.paper</groupId>
+      <artifactId>paper-api</artifactId>
+      <version>1.21.1-R0.1-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/nations/src/main/java/com/example/nations/NationsPlugin.java
+++ b/nations/src/main/java/com/example/nations/NationsPlugin.java
@@ -1,0 +1,30 @@
+package com.example.nations;
+
+import com.example.nations.commands.NationCommand;
+import com.example.nations.model.NationRegistry;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class NationsPlugin extends JavaPlugin {
+    private NationRegistry nationRegistry;
+
+    @Override
+    public void onEnable() {
+        this.nationRegistry = new NationRegistry();
+        PluginCommand cmd = getCommand("nation");
+        if (cmd != null) {
+            cmd.setExecutor(new NationCommand(this));
+            cmd.setTabCompleter(new NationCommand(this));
+        }
+        getLogger().info("Nations plugin enabled");
+    }
+
+    @Override
+    public void onDisable() {
+        getLogger().info("Nations plugin disabled");
+    }
+
+    public NationRegistry getNationRegistry() {
+        return nationRegistry;
+    }
+}

--- a/nations/src/main/java/com/example/nations/commands/NationCommand.java
+++ b/nations/src/main/java/com/example/nations/commands/NationCommand.java
@@ -1,0 +1,82 @@
+package com.example.nations.commands;
+
+import com.example.nations.NationsPlugin;
+import com.example.nations.model.Nation;
+import com.example.nations.model.NationRegistry;
+import com.example.nations.territory.ChunkPosition;
+import org.bukkit.Chunk;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class NationCommand implements CommandExecutor, TabCompleter {
+    private final NationsPlugin plugin;
+
+    public NationCommand(NationsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Only players can use this command.");
+            return true;
+        }
+
+        if (args.length == 0) {
+            sender.sendMessage("Usage: /" + label + " <create|claim>");
+            return true;
+        }
+
+        NationRegistry registry = plugin.getNationRegistry();
+
+        switch (args[0].toLowerCase()) {
+            case "create" -> {
+                if (args.length < 2) {
+                    sender.sendMessage("Usage: /" + label + " create <name>");
+                    return true;
+                }
+                String name = args[1];
+                if (registry.getNation(name) != null) {
+                    sender.sendMessage("Nation already exists.");
+                    return true;
+                }
+                registry.createNation(name, player.getUniqueId());
+                sender.sendMessage("Nation " + name + " created.");
+            }
+            case "claim" -> {
+                Nation nation = registry.getNationByMember(player.getUniqueId());
+                if (nation == null) {
+                    sender.sendMessage("You are not part of a nation.");
+                    return true;
+                }
+                Chunk chunk = player.getLocation().getChunk();
+                ChunkPosition pos = ChunkPosition.fromChunk(chunk);
+                if (nation.getTerritory().contains(pos)) {
+                    sender.sendMessage("This chunk is already claimed by your nation.");
+                    return true;
+                }
+                nation.getTerritory().add(pos);
+                sender.sendMessage("Chunk claimed for " + nation.getName() + ".");
+            }
+            default -> sender.sendMessage("Unknown subcommand.");
+        }
+
+        return true;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        List<String> completions = new ArrayList<>();
+        if (args.length == 1) {
+            completions.add("create");
+            completions.add("claim");
+        }
+        return completions;
+    }
+}

--- a/nations/src/main/java/com/example/nations/diplomacy/DiplomacyManager.java
+++ b/nations/src/main/java/com/example/nations/diplomacy/DiplomacyManager.java
@@ -1,0 +1,27 @@
+package com.example.nations.diplomacy;
+
+import com.example.nations.model.Nation;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Tracks relationships and treaties between nations.
+ * This is a placeholder for future diplomacy features.
+ */
+public class DiplomacyManager {
+    private final Map<UUID, Map<UUID, RelationType>> relations = new HashMap<>();
+
+    public RelationType getRelation(Nation a, Nation b) {
+        return relations.getOrDefault(a.getFounder(), Map.of())
+                .getOrDefault(b.getFounder(), RelationType.NEUTRAL);
+    }
+
+    public void setRelation(Nation a, Nation b, RelationType type) {
+        relations.computeIfAbsent(a.getFounder(), k -> new HashMap<>())
+                .put(b.getFounder(), type);
+        relations.computeIfAbsent(b.getFounder(), k -> new HashMap<>())
+                .put(a.getFounder(), type);
+    }
+}

--- a/nations/src/main/java/com/example/nations/diplomacy/RelationType.java
+++ b/nations/src/main/java/com/example/nations/diplomacy/RelationType.java
@@ -1,0 +1,7 @@
+package com.example.nations.diplomacy;
+
+public enum RelationType {
+    NEUTRAL,
+    ALLY,
+    ENEMY
+}

--- a/nations/src/main/java/com/example/nations/model/Nation.java
+++ b/nations/src/main/java/com/example/nations/model/Nation.java
@@ -1,0 +1,36 @@
+package com.example.nations.model;
+
+import com.example.nations.territory.ChunkPosition;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public class Nation {
+    private final String name;
+    private final UUID founder;
+    private final Set<UUID> citizens = new HashSet<>();
+    private final Set<ChunkPosition> territory = new HashSet<>();
+
+    public Nation(String name, UUID founder) {
+        this.name = name;
+        this.founder = founder;
+        this.citizens.add(founder);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public UUID getFounder() {
+        return founder;
+    }
+
+    public Set<UUID> getCitizens() {
+        return citizens;
+    }
+
+    public Set<ChunkPosition> getTerritory() {
+        return territory;
+    }
+}

--- a/nations/src/main/java/com/example/nations/model/NationRegistry.java
+++ b/nations/src/main/java/com/example/nations/model/NationRegistry.java
@@ -1,0 +1,26 @@
+package com.example.nations.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class NationRegistry {
+    private final Map<String, Nation> nations = new HashMap<>();
+
+    public Nation getNation(String name) {
+        return nations.get(name.toLowerCase());
+    }
+
+    public Nation getNationByMember(UUID uuid) {
+        return nations.values().stream()
+                .filter(n -> n.getCitizens().contains(uuid))
+                .findFirst()
+                .orElse(null);
+    }
+
+    public Nation createNation(String name, UUID founder) {
+        Nation nation = new Nation(name, founder);
+        nations.put(name.toLowerCase(), nation);
+        return nation;
+    }
+}

--- a/nations/src/main/java/com/example/nations/territory/ChunkPosition.java
+++ b/nations/src/main/java/com/example/nations/territory/ChunkPosition.java
@@ -1,0 +1,29 @@
+package com.example.nations.territory;
+
+import org.bukkit.Chunk;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record ChunkPosition(UUID world, int x, int z) {
+    public static ChunkPosition fromChunk(Chunk chunk) {
+        return new ChunkPosition(chunk.getWorld().getUID(), chunk.getX(), chunk.getZ());
+    }
+
+    @Override
+    public String toString() {
+        return world + ":" + x + ":" + z;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ChunkPosition that)) return false;
+        return x == that.x && z == that.z && world.equals(that.world);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(world, x, z);
+    }
+}

--- a/nations/src/main/java/com/example/nations/territory/TerritoryManager.java
+++ b/nations/src/main/java/com/example/nations/territory/TerritoryManager.java
@@ -1,0 +1,12 @@
+package com.example.nations.territory;
+
+import com.example.nations.model.Nation;
+
+/**
+ * Handles claiming and unclaiming chunks for nations.
+ */
+public class TerritoryManager {
+    public void claim(Nation nation, ChunkPosition pos) {
+        nation.getTerritory().add(pos);
+    }
+}

--- a/nations/src/main/java/com/example/nations/war/WarManager.java
+++ b/nations/src/main/java/com/example/nations/war/WarManager.java
@@ -1,0 +1,12 @@
+package com.example.nations.war;
+
+import com.example.nations.model.Nation;
+
+/**
+ * Placeholder class for war mechanics such as countdowns and scoring.
+ */
+public class WarManager {
+    public void declareWar(Nation attacker, Nation defender) {
+        // TODO implement war declaration logic
+    }
+}

--- a/nations/src/main/resources/plugin.yml
+++ b/nations/src/main/resources/plugin.yml
@@ -1,0 +1,9 @@
+name: Nations
+version: 0.1.0
+main: com.example.nations.NationsPlugin
+api-version: '1.21'
+commands:
+  nation:
+    description: Manage nations
+    usage: /<command> <create|claim|relation|war>
+    permission: nations.command


### PR DESCRIPTION
## Summary
- scaffold a new Nations plugin with basic nation creation and chunk claiming commands
- include placeholders for diplomacy and war mechanics
- add reusable build script and ignore new target directory

## Testing
- `./compile.sh nations` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a48bedaea0832494d1ce39d017f69d