### PR TITLE
Add Chrono time-travel Purpur plugin skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ignore Maven build output
 living/target/
+chrono/target/
 # Ignore IDE files
 *.iml
 .idea/

--- a/chrono/compile.sh
+++ b/chrono/compile.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+# Install Java 21 if missing
+if ! command -v java >/dev/null 2>&1 || ! java -version 2>&1 | grep -q '21'; then
+  echo "Installing OpenJDK 21..."
+  sudo apt-get update
+  sudo apt-get install -y openjdk-21-jdk
+fi
+
+# Install Maven if missing
+if ! command -v mvn >/dev/null 2>&1; then
+  echo "Installing Maven..."
+  sudo apt-get update
+  sudo apt-get install -y maven
+fi
+
+# Build the plugin
+mvn -B package
+
+echo "Build complete. Jar located in target/"

--- a/chrono/pom.xml
+++ b/chrono/pom.xml
@@ -1,0 +1,40 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>net.timeux</groupId>
+    <artifactId>chrono</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <name>Chrono</name>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <repositories>
+        <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+    </repositories>
+    <dependencies>
+        <dependency>
+            <groupId>org.purpurmc.purpur</groupId>
+            <artifactId>purpur-api</artifactId>
+            <version>1.21.5-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>21</source>
+                    <target>21</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/chrono/src/main/java/net/timeux/chrono/ChronoPlugin.java
+++ b/chrono/src/main/java/net/timeux/chrono/ChronoPlugin.java
@@ -1,0 +1,85 @@
+package net.timeux.chrono;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Set;
+
+public class ChronoPlugin extends JavaPlugin implements Listener {
+
+    private final Set<Material> allowedBreak = EnumSet.of(
+            Material.STONE,
+            Material.COAL_ORE,
+            Material.IRON_ORE,
+            Material.DIAMOND_ORE,
+            Material.GOLD_ORE
+    );
+
+    private SnapshotManager snapshotManager;
+
+    @Override
+    public void onEnable() {
+        this.snapshotManager = new SnapshotManager(this);
+        getServer().getPluginManager().registerEvents(this, this);
+
+        getCommand("chronosnapshot").setExecutor((sender, command, label, args) -> {
+            if (args.length != 1) {
+                sender.sendMessage("Usage: /chronosnapshot <name>");
+                return true;
+            }
+            try {
+                snapshotManager.createSnapshot(args[0]);
+                sender.sendMessage("Snapshot " + args[0] + " erstellt.");
+            } catch (IOException e) {
+                sender.sendMessage("Snapshot fehlgeschlagen: " + e.getMessage());
+                e.printStackTrace();
+            }
+            return true;
+        });
+
+        getCommand("chronoportal").setExecutor((sender, command, label, args) -> {
+            if (!(sender instanceof org.bukkit.entity.Player player)) {
+                sender.sendMessage("Nur Spieler können dieses Kommando nutzen.");
+                return true;
+            }
+            if (args.length == 1 && args[0].equalsIgnoreCase("return")) {
+                World main = Bukkit.getWorlds().get(0);
+                player.teleport(main.getSpawnLocation(), PlayerTeleportEvent.TeleportCause.PLUGIN);
+                ItemFilter.filterInventory(player.getInventory());
+                return true;
+            }
+            if (args.length != 1) {
+                sender.sendMessage("Usage: /chronoportal <snapshot>");
+                return true;
+            }
+            World snapshotWorld = Bukkit.getWorld(args[0]);
+            if (snapshotWorld == null) {
+                sender.sendMessage("Snapshot nicht gefunden.");
+                return true;
+            }
+            player.teleport(snapshotWorld.getSpawnLocation(), PlayerTeleportEvent.TeleportCause.PLUGIN);
+            return true;
+        });
+    }
+
+    @EventHandler
+    public void onBlockBreak(BlockBreakEvent event) {
+        if (!allowedBreak.contains(event.getBlock().getType())) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onBlockPlace(BlockPlaceEvent event) {
+        event.setCancelled(true);
+    }
+}

--- a/chrono/src/main/java/net/timeux/chrono/ItemFilter.java
+++ b/chrono/src/main/java/net/timeux/chrono/ItemFilter.java
@@ -1,0 +1,33 @@
+package net.timeux.chrono;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+public final class ItemFilter {
+
+    private static final Set<Material> ALLOWED_ITEMS = EnumSet.of(
+            Material.STONE,
+            Material.COBBLESTONE,
+            Material.COAL,
+            Material.IRON_ORE,
+            Material.DIAMOND
+    );
+
+    private ItemFilter() {
+    }
+
+    public static void filterInventory(Inventory inv) {
+        for (ItemStack stack : inv.getContents()) {
+            if (stack == null) {
+                continue;
+            }
+            if (!ALLOWED_ITEMS.contains(stack.getType())) {
+                inv.remove(stack);
+            }
+        }
+    }
+}

--- a/chrono/src/main/java/net/timeux/chrono/SnapshotManager.java
+++ b/chrono/src/main/java/net/timeux/chrono/SnapshotManager.java
@@ -1,0 +1,41 @@
+package net.timeux.chrono;
+
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.WorldCreator;
+import org.bukkit.plugin.Plugin;
+
+import java.io.IOException;
+import java.nio.file.*;
+
+public class SnapshotManager {
+
+    private final Plugin plugin;
+
+    public SnapshotManager(Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void createSnapshot(String name) throws IOException {
+        World source = Bukkit.getWorlds().get(0);
+        Path src = source.getWorldFolder().toPath();
+        Path dest = Bukkit.getWorldContainer().toPath().resolve(name);
+        if (Files.exists(dest)) {
+            throw new IOException("Snapshot existiert bereits");
+        }
+        Files.walk(src).forEach(path -> {
+            try {
+                Path target = dest.resolve(src.relativize(path));
+                if (Files.isDirectory(path)) {
+                    Files.createDirectories(target);
+                } else {
+                    Files.copy(path, target, StandardCopyOption.REPLACE_EXISTING);
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        WorldCreator wc = new WorldCreator(name);
+        Bukkit.createWorld(wc);
+    }
+}

--- a/chrono/src/main/resources/plugin.yml
+++ b/chrono/src/main/resources/plugin.yml
@@ -1,0 +1,20 @@
+name: Chrono
+version: 0.1.0
+main: net.timeux.chrono.ChronoPlugin
+api-version: 1.21
+commands:
+  chronosnapshot:
+    description: Snapshot einer Welt erstellen
+    usage: /chronosnapshot <name>
+    permission: chrono.snapshot
+  chronoportal:
+    description: Teleportiere zu einem Snapshot oder zurück
+    usage: /chronoportal <snapshot|return>
+    permission: chrono.portal
+permissions:
+  chrono.snapshot:
+    description: Erlaube Erstellen von Snapshots
+    default: op
+  chrono.portal:
+    description: Erlaube Nutzung von Chrono-Portalen
+    default: true


### PR DESCRIPTION
## Summary
- add Chrono plugin skeleton for time travel with snapshot creation, portal travel, block restrictions, and inventory filtering
- include Maven build configuration and compile script for Debian environments
- update gitignore for build artifacts

## Testing
- `cd chrono && ./compile.sh` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a48ca89d0c832493b6fc9b69ca3034