### PR TITLE
Add skeleton for Living NPC city plugin with build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Ignore Maven build output
+living/target/
+# Ignore IDE files
+*.iml
+.idea/
+.classpath
+.project
+.settings/
+# Ignore OS files
+.DS_Store

--- a/compile.sh
+++ b/compile.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# Script to build the Living plugin on Debian based systems.
+# It installs required dependencies (OpenJDK and Maven) and
+# then compiles the plugin using Maven.
+
+if ! command -v javac >/dev/null 2>&1; then
+    echo "Installing OpenJDK 21..."
+    sudo apt-get update
+    sudo apt-get install -y openjdk-21-jdk
+fi
+
+if ! command -v mvn >/dev/null 2>&1; then
+    echo "Installing Maven..."
+    sudo apt-get update
+    sudo apt-get install -y maven
+fi
+
+cd "$(dirname "$0")/living"
+
+mvn -B package
+
+echo "Build completed. The plugin jar can be found in living/target."

--- a/living/pom.xml
+++ b/living/pom.xml
@@ -1,0 +1,47 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>living</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Living</name>
+    <description>Dynamic NPC-driven city simulation plugin.</description>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.21.5-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <release>21</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/living/src/main/java/com/example/living/LivingPlugin.java
+++ b/living/src/main/java/com/example/living/LivingPlugin.java
@@ -1,0 +1,44 @@
+package com.example.living;
+
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Main plugin class for the Living NPC city simulation.
+ * This class is responsible for initializing managers that handle
+ * cities, NPCs and their tasks. The real game logic is still to be
+ * implemented and currently acts as a scaffold.
+ */
+public class LivingPlugin extends JavaPlugin {
+
+    private static LivingPlugin instance;
+    private String disableReason = "Server shutdown or reload";
+
+    @Override
+    public void onEnable() {
+        instance = this;
+        getLogger().info("Living plugin enabled. Placeholder simulation initialized.");
+        // Future initialization of managers such as CityManager, NPCManager etc.
+    }
+
+    @Override
+    public void onDisable() {
+        getLogger().info("Living plugin disabled: " + disableReason);
+        instance = null;
+    }
+
+    /**
+     * Disable this plugin with a specific reason that will be logged to the console.
+     *
+     * @param reason explanation why the plugin is being disabled
+     */
+    public void disablePlugin(String reason) {
+        this.disableReason = reason;
+        getLogger().warning("Disabling Living plugin: " + reason);
+        Bukkit.getPluginManager().disablePlugin(this);
+    }
+
+    public static LivingPlugin getInstance() {
+        return instance;
+    }
+}

--- a/living/src/main/java/com/example/living/city/City.java
+++ b/living/src/main/java/com/example/living/city/City.java
@@ -1,0 +1,43 @@
+package com.example.living.city;
+
+import com.example.living.LivingPlugin;
+import com.example.living.npc.NPC;
+import java.util.ArrayList;
+import java.util.List;
+import org.bukkit.Location;
+
+/**
+ * Represents a city in the simulation. Cities hold NPCs and track
+ * resources and buildings. Only minimal data structures are provided
+ * for now to allow future expansion.
+ */
+public class City {
+
+    private final String name;
+    private final Location coreLocation;
+    private final List<NPC> npcs = new ArrayList<>();
+
+    public City(String name, Location coreLocation) {
+        this.name = name;
+        this.coreLocation = coreLocation;
+        LivingPlugin.getInstance().getLogger().info("City created: " + name);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Location getCoreLocation() {
+        return coreLocation;
+    }
+
+    public List<NPC> getNpcs() {
+        return npcs;
+    }
+
+    public void addNpc(NPC npc) {
+        npcs.add(npc);
+        LivingPlugin.getInstance().getLogger()
+                .info("NPC with job " + npc.getJob() + " added to city " + name);
+    }
+}

--- a/living/src/main/java/com/example/living/npc/Job.java
+++ b/living/src/main/java/com/example/living/npc/Job.java
@@ -1,0 +1,11 @@
+package com.example.living.npc;
+
+/**
+ * Enumeration of supported NPC jobs.
+ */
+public enum Job {
+    WOODCUTTER,
+    MINER,
+    FARMER,
+    BUILDER
+}

--- a/living/src/main/java/com/example/living/npc/NPC.java
+++ b/living/src/main/java/com/example/living/npc/NPC.java
@@ -1,0 +1,42 @@
+package com.example.living.npc;
+
+import java.util.UUID;
+import com.example.living.LivingPlugin;
+
+/**
+ * Basic representation of an NPC controlled by the plugin.
+ * The implementation here is intentionally lightweight and is
+ * meant to be expanded with behavior logic, pathfinding and
+ * interaction with the Minecraft world.
+ */
+public class NPC {
+
+    private final UUID uuid;
+    private final Job job;
+
+    public NPC(UUID uuid, Job job) {
+        this.uuid = uuid;
+        this.job = job;
+        LivingPlugin.getInstance().getLogger()
+                .info("NPC created with job " + job + " and UUID " + uuid);
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public Job getJob() {
+        return job;
+    }
+
+    /**
+     * Placeholder method representing a task execution.
+     * Actual implementation would use server APIs to interact
+     * with blocks, inventories and other entities.
+     */
+    public void performTask() {
+        LivingPlugin.getInstance().getLogger()
+                .info("NPC " + uuid + " performing job " + job + " task.");
+        // TODO: implement actual job logic
+    }
+}

--- a/living/src/main/resources/config.yml
+++ b/living/src/main/resources/config.yml
@@ -1,0 +1,3 @@
+# Default configuration for Living plugin
+city:
+  maxNPCs: 50

--- a/living/src/main/resources/plugin.yml
+++ b/living/src/main/resources/plugin.yml
@@ -1,0 +1,6 @@
+name: Living
+version: 0.1.0
+main: com.example.living.LivingPlugin
+description: Dynamic NPC-driven city simulation plugin.
+api-version: "1.21"
+load: POSTWORLD


### PR DESCRIPTION
## Summary
- add initial Maven project for dynamic NPC-driven cities
- include basic City, NPC, and job classes
- provide compile.sh to install dependencies and build the plugin
- add console logging for city creation, NPC activity, and plugin disable reasons

## Testing
- `./compile.sh` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a481e039e4832496785b66e9c3bd9b