### PR TITLE
Add configurable city and nation systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,15 @@
 # Ignore Maven build output
 living/target/
 chrono/target/
+nations/target/
+
 # Ignore IDE files
 *.iml
 .idea/
 .classpath
 .project
 .settings/
+
 # Ignore OS files
 .DS_Store
+

--- a/compile.sh
+++ b/compile.sh
@@ -19,7 +19,7 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-for module in living chrono; do
+for module in living chrono nations; do
     if [ -d "$SCRIPT_DIR/$module" ]; then
         cd "$SCRIPT_DIR/$module"
         mvn -B package

--- a/living/src/main/java/com/example/living/LivingPlugin.java
+++ b/living/src/main/java/com/example/living/LivingPlugin.java
@@ -1,7 +1,17 @@
 package com.example.living;
 
+import java.util.EnumMap;
+import java.util.Map;
+
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.plugin.java.JavaPlugin;
+
+import com.example.living.npc.Job;
+import com.example.living.manager.CityManager;
+import com.example.living.manager.NPCManager;
+import com.example.living.listener.CityCoreListener;
 
 /**
  * Main plugin class for the Living NPC city simulation.
@@ -13,12 +23,17 @@ public class LivingPlugin extends JavaPlugin {
 
     private static LivingPlugin instance;
     private String disableReason = "Server shutdown or reload";
+    private CityManager cityManager;
+    private NPCManager npcManager;
 
     @Override
     public void onEnable() {
         instance = this;
+        saveDefaultConfig();
+        this.cityManager = new CityManager(this);
+        this.npcManager = new NPCManager(this);
+        getServer().getPluginManager().registerEvents(new CityCoreListener(this), this);
         getLogger().info("Living plugin enabled. Placeholder simulation initialized.");
-        // Future initialization of managers such as CityManager, NPCManager etc.
     }
 
     @Override
@@ -40,5 +55,41 @@ public class LivingPlugin extends JavaPlugin {
 
     public static LivingPlugin getInstance() {
         return instance;
+    }
+
+    public CityManager getCityManager() {
+        return cityManager;
+    }
+
+    public NPCManager getNpcManager() {
+        return npcManager;
+    }
+
+    public Material getCoreMaterial() {
+        String matName = getConfig().getString("city.core-material", "LODESTONE");
+        Material material = Material.matchMaterial(matName);
+        return material != null ? material : Material.LODESTONE;
+    }
+
+    public int getMaxNpcs() {
+        return getConfig().getInt("city.max-npcs", 50);
+    }
+
+    public int getSpawnInterval() {
+        return getConfig().getInt("city.spawn-interval", 600);
+    }
+
+    public int getNpcTaskInterval() {
+        return getConfig().getInt("npc.task-interval", 200);
+    }
+
+    public Map<Job, Integer> getInitialJobs() {
+        Map<Job, Integer> map = new EnumMap<>(Job.class);
+        ConfigurationSection section = getConfig().getConfigurationSection("city.initial-jobs");
+        for (Job job : Job.values()) {
+            int amount = section != null ? section.getInt(job.name().toLowerCase(), 0) : 0;
+            map.put(job, amount);
+        }
+        return map;
     }
 }

--- a/living/src/main/java/com/example/living/listener/CityCoreListener.java
+++ b/living/src/main/java/com/example/living/listener/CityCoreListener.java
@@ -1,0 +1,30 @@
+package com.example.living.listener;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockPlaceEvent;
+
+import com.example.living.LivingPlugin;
+
+/**
+ * Reagiert auf das Platzieren eines Stadtkern-Blocks und erstellt eine neue Stadt.
+ */
+public class CityCoreListener implements Listener {
+
+    private final LivingPlugin plugin;
+
+    public CityCoreListener(LivingPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onBlockPlace(BlockPlaceEvent event) {
+        if (event.getBlockPlaced().getType() != plugin.getCoreMaterial()) {
+            return;
+        }
+        String name = event.getPlayer().getName() + "'s City";
+        plugin.getCityManager().createCity(name, event.getBlockPlaced().getLocation());
+        event.getPlayer().sendMessage("Stadt '" + name + "' gegründet!");
+    }
+}
+

--- a/living/src/main/java/com/example/living/manager/CityManager.java
+++ b/living/src/main/java/com/example/living/manager/CityManager.java
@@ -1,0 +1,48 @@
+package com.example.living.manager;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+
+import com.example.living.LivingPlugin;
+import com.example.living.city.City;
+import com.example.living.npc.Job;
+
+/**
+ * Verwaltet alle existierenden Städte und kümmert sich um das
+ * periodische Erweitern der Bevölkerung.
+ */
+public class CityManager {
+    private final LivingPlugin plugin;
+    private final List<City> cities = new ArrayList<>();
+    private final Random random = new Random();
+
+    public CityManager(LivingPlugin plugin) {
+        this.plugin = plugin;
+        Bukkit.getScheduler().runTaskTimer(plugin, this::tickCities, plugin.getSpawnInterval(), plugin.getSpawnInterval());
+    }
+
+    public City createCity(String name, Location core) {
+        City city = new City(name, core);
+        cities.add(city);
+        plugin.getNpcManager().spawnInitialNpcs(city);
+        return city;
+    }
+
+    public List<City> getCities() {
+        return cities;
+    }
+
+    private void tickCities() {
+        for (City city : cities) {
+            if (city.getNpcs().size() < plugin.getMaxNpcs()) {
+                Job job = Job.values()[random.nextInt(Job.values().length)];
+                plugin.getNpcManager().spawnNpc(city, job);
+            }
+        }
+    }
+}
+

--- a/living/src/main/java/com/example/living/manager/NPCManager.java
+++ b/living/src/main/java/com/example/living/manager/NPCManager.java
@@ -1,0 +1,49 @@
+package com.example.living.manager;
+
+import java.util.Map;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Villager;
+import org.bukkit.scheduler.BukkitScheduler;
+
+import com.example.living.LivingPlugin;
+import com.example.living.city.City;
+import com.example.living.npc.Job;
+import com.example.living.npc.NPC;
+
+/**
+ * Erzeugt und verwaltet NPC-Entitäten für Städte.
+ */
+public class NPCManager {
+    private final LivingPlugin plugin;
+
+    public NPCManager(LivingPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void spawnInitialNpcs(City city) {
+        Map<Job, Integer> jobs = plugin.getInitialJobs();
+        for (Map.Entry<Job, Integer> entry : jobs.entrySet()) {
+            for (int i = 0; i < entry.getValue(); i++) {
+                spawnNpc(city, entry.getKey());
+            }
+        }
+    }
+
+    public NPC spawnNpc(City city, Job job) {
+        if (city.getNpcs().size() >= plugin.getMaxNpcs()) {
+            plugin.getLogger().warning("Max NPCs reached for city " + city.getName());
+            return null;
+        }
+        Location loc = city.getCoreLocation();
+        Villager villager = loc.getWorld().spawn(loc, Villager.class);
+        villager.setCustomName(job.name());
+        villager.setCustomNameVisible(true);
+        NPC npc = new NPC(villager.getUniqueId(), job);
+        city.addNpc(npc);
+        BukkitScheduler scheduler = plugin.getServer().getScheduler();
+        scheduler.runTaskTimer(plugin, npc::performTask, plugin.getNpcTaskInterval(), plugin.getNpcTaskInterval());
+        return npc;
+    }
+}
+

--- a/living/src/main/resources/config.yml
+++ b/living/src/main/resources/config.yml
@@ -1,3 +1,18 @@
-# Default configuration for Living plugin
+# Konfiguration für das Living-Plugin
+
 city:
-  maxNPCs: 50
+  core-material: LODESTONE # Block, der als Stadtkern dient. Wird dieser Block platziert, entsteht eine neue Stadt.
+  max-npcs: 50            # Maximale Anzahl an NPCs, die eine Stadt gleichzeitig haben darf.
+  spawn-interval: 600     # Ticks zwischen Versuchen, neue NPCs zu erschaffen (20 Ticks = 1 Sekunde).
+  initial-jobs:           # Anzahl der NPCs je Beruf, die beim Erstellen einer Stadt gespawnt werden.
+    woodcutter: 1         # Holzfäller sammeln Holz in der Umgebung.
+    miner: 1              # Miner suchen nach Erzen unter der Stadt.
+    farmer: 1             # Farmer kümmern sich um Felder und Lebensmittel.
+    builder: 1            # Baumeister errichten neue Gebäude nach Blaupausen.
+
+storage:
+  chest-radius: 10        # Radius in Blöcken um den Stadtkern, in dem Lagerkisten erkannt und genutzt werden.
+
+npc:
+  task-interval: 200      # Ticks zwischen den Ausführungen der Aufgaben eines NPCs.
+

--- a/nations/pom.xml
+++ b/nations/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>io.papermc.paper</groupId>
       <artifactId>paper-api</artifactId>
-      <version>1.21.1-R0.1-SNAPSHOT</version>
+      <version>1.21.5-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/nations/src/main/java/com/example/nations/NationsPlugin.java
+++ b/nations/src/main/java/com/example/nations/NationsPlugin.java
@@ -1,20 +1,31 @@
 package com.example.nations;
 
 import com.example.nations.commands.NationCommand;
+import com.example.nations.diplomacy.DiplomacyManager;
+import com.example.nations.diplomacy.RelationType;
 import com.example.nations.model.NationRegistry;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class NationsPlugin extends JavaPlugin {
     private NationRegistry nationRegistry;
+    private DiplomacyManager diplomacyManager;
+    private int maxCitizens;
+    private int maxTerritory;
+    private boolean warEnabled;
+    private RelationType defaultRelation;
 
     @Override
     public void onEnable() {
+        saveDefaultConfig();
         this.nationRegistry = new NationRegistry();
+        this.diplomacyManager = new DiplomacyManager();
+        reloadSettings();
         PluginCommand cmd = getCommand("nation");
         if (cmd != null) {
-            cmd.setExecutor(new NationCommand(this));
-            cmd.setTabCompleter(new NationCommand(this));
+            NationCommand executor = new NationCommand(this);
+            cmd.setExecutor(executor);
+            cmd.setTabCompleter(executor);
         }
         getLogger().info("Nations plugin enabled");
     }
@@ -24,7 +35,39 @@ public class NationsPlugin extends JavaPlugin {
         getLogger().info("Nations plugin disabled");
     }
 
+    public void reloadSettings() {
+        this.maxCitizens = getConfig().getInt("limits.max-citizens", 50);
+        this.maxTerritory = getConfig().getInt("limits.max-territory-chunks", 100);
+        this.warEnabled = getConfig().getBoolean("war.enabled", true);
+        String rel = getConfig().getString("diplomacy.default-relation", "NEUTRAL");
+        try {
+            this.defaultRelation = RelationType.valueOf(rel.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            this.defaultRelation = RelationType.NEUTRAL;
+        }
+    }
+
     public NationRegistry getNationRegistry() {
         return nationRegistry;
+    }
+
+    public DiplomacyManager getDiplomacyManager() {
+        return diplomacyManager;
+    }
+
+    public int getMaxCitizens() {
+        return maxCitizens;
+    }
+
+    public int getMaxTerritory() {
+        return maxTerritory;
+    }
+
+    public boolean isWarEnabled() {
+        return warEnabled;
+    }
+
+    public RelationType getDefaultRelation() {
+        return defaultRelation;
     }
 }

--- a/nations/src/main/java/com/example/nations/commands/NationCommand.java
+++ b/nations/src/main/java/com/example/nations/commands/NationCommand.java
@@ -46,13 +46,22 @@ public class NationCommand implements CommandExecutor, TabCompleter {
                     sender.sendMessage("Nation already exists.");
                     return true;
                 }
-                registry.createNation(name, player.getUniqueId());
+                Nation nation = registry.createNation(name, player.getUniqueId());
+                for (Nation other : registry.getNations()) {
+                    if (other != nation) {
+                        plugin.getDiplomacyManager().setRelation(nation, other, plugin.getDefaultRelation());
+                    }
+                }
                 sender.sendMessage("Nation " + name + " created.");
             }
             case "claim" -> {
                 Nation nation = registry.getNationByMember(player.getUniqueId());
                 if (nation == null) {
                     sender.sendMessage("You are not part of a nation.");
+                    return true;
+                }
+                if (nation.getTerritory().size() >= plugin.getMaxTerritory()) {
+                    sender.sendMessage("Your nation has reached the territory limit.");
                     return true;
                 }
                 Chunk chunk = player.getLocation().getChunk();

--- a/nations/src/main/java/com/example/nations/model/NationRegistry.java
+++ b/nations/src/main/java/com/example/nations/model/NationRegistry.java
@@ -1,5 +1,6 @@
 package com.example.nations.model;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -22,5 +23,9 @@ public class NationRegistry {
         Nation nation = new Nation(name, founder);
         nations.put(name.toLowerCase(), nation);
         return nation;
+    }
+
+    public Collection<Nation> getNations() {
+        return nations.values();
     }
 }

--- a/nations/src/main/resources/config.yml
+++ b/nations/src/main/resources/config.yml
@@ -1,0 +1,13 @@
+# Konfiguration für das Nations-Plugin
+
+limits:
+  max-citizens: 50          # Maximale Anzahl an Bürgern in einer Nation.
+  max-territory-chunks: 100 # Maximale Anzahl an Chunks, die eine Nation beanspruchen darf.
+
+war:
+  enabled: true             # Ob Kriege zwischen Nationen erlaubt sind.
+  declare-cost: 0           # Platzhalterwert für die Kosten einer Kriegserklärung.
+
+diplomacy:
+  default-relation: NEUTRAL # Standard-Beziehungsstatus zwischen neu gegründeten Nationen.
+


### PR DESCRIPTION
## Summary
- add comprehensive YAML configs for Living and Nations plugins
- implement city creation and NPC management based on configurable settings
- enforce nation limits and default relations through new config values

## Testing
- `mvn -q package` *(fails: Could not resolve maven-resources-plugin, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c7d0818883248263436d5958a7d2