### PR TITLE
Add crafting NPC and resource routing

### DIFF
--- a/living/src/main/java/com/example/living/manager/NPCManager.java
+++ b/living/src/main/java/com/example/living/manager/NPCManager.java
@@ -134,10 +134,11 @@ public class NPCManager {
 
         // Job-spezifische Optionen
         if (npc.getJob() == Job.WOODCUTTER) {
-            ItemStack tree = new ItemStack(Material.OAK_SAPLING);
+            String type = npc.getTaskParameters().getOrDefault("tree", "OAK");
+            Material saplingMat = Material.matchMaterial(type + "_SAPLING");
+            ItemStack tree = new ItemStack(saplingMat != null ? saplingMat : Material.OAK_SAPLING);
             ItemMeta treeMeta = tree.getItemMeta();
             if (treeMeta != null) {
-                String type = npc.getTaskParameters().getOrDefault("tree", "OAK");
                 treeMeta.displayName(Component.text("Tree: " + type));
                 treeMeta.getPersistentDataContainer().set(npcUuidKey, PersistentDataType.STRING, npc.getUuid().toString());
                 tree.setItemMeta(treeMeta);
@@ -211,11 +212,14 @@ public class NPCManager {
             npc.setActive(!npc.isActive());
             saveNpcSettings(npc);
             openNpcSettingsGui(player, npc);
-        } else if (type == Material.OAK_SAPLING) {
+        } else if (type.name().endsWith("_SAPLING")) {
             String current = npc.getTaskParameters().getOrDefault("tree", "OAK");
             String next = switch (current) {
                 case "OAK" -> "BIRCH";
                 case "BIRCH" -> "SPRUCE";
+                case "SPRUCE" -> "JUNGLE";
+                case "JUNGLE" -> "ACACIA";
+                case "ACACIA" -> "OAK";
                 default -> "OAK";
             };
             npc.setTaskParameter("tree", next);

--- a/living/src/main/java/com/example/living/npc/Job.java
+++ b/living/src/main/java/com/example/living/npc/Job.java
@@ -7,5 +7,6 @@ public enum Job {
     WOODCUTTER,
     MINER,
     FARMER,
-    BUILDER
+    BUILDER,
+    CRAFTER
 }

--- a/living/src/main/java/com/example/living/npc/NPC.java
+++ b/living/src/main/java/com/example/living/npc/NPC.java
@@ -92,6 +92,7 @@ public class NPC {
             case MINER -> performMinerTask(villager);
             case FARMER -> performFarmerTask(villager);
             case BUILDER -> performBuilderTask(villager);
+            case CRAFTER -> performCrafterTask(villager);
             default -> {
                 // no-op for unhandled jobs
             }
@@ -115,9 +116,7 @@ public class NPC {
                     Block block = loc.getBlock().getRelative(x, y, z);
                     if (block.getType() == logMaterial) {
                         block.breakNaturally();
-                        if (city != null) {
-                            city.addResource(logMaterial, 1);
-                        }
+                        addChestItems(logMaterial, 1);
                         plugin.getLogger().info("NPC " + uuid + " cut a " + tree + " log.");
                         return;
                     }
@@ -130,17 +129,18 @@ public class NPC {
         LivingPlugin plugin = LivingPlugin.getInstance();
         Location loc = villager.getLocation();
         int radius = 5;
+        Material[] mineables = {Material.STONE, Material.SAND, Material.GRASS_BLOCK, Material.DIRT};
         for (int x = -radius; x <= radius; x++) {
             for (int y = -radius; y <= radius; y++) {
                 for (int z = -radius; z <= radius; z++) {
                     Block block = loc.getBlock().getRelative(x, y, z);
-                    if (block.getType() == Material.STONE) {
-                        block.breakNaturally();
-                        if (city != null) {
-                            city.addResource(Material.STONE, 1);
+                    for (Material mat : mineables) {
+                        if (block.getType() == mat) {
+                            block.breakNaturally();
+                            addChestItems(mat, 1);
+                            plugin.getLogger().info("NPC " + uuid + " mined " + mat.name().toLowerCase() + ".");
+                            return;
                         }
-                        plugin.getLogger().info("NPC " + uuid + " mined stone.");
-                        return;
                     }
                 }
             }
@@ -158,14 +158,74 @@ public class NPC {
                     if (block.getType() == Material.WHEAT) {
                         block.breakNaturally();
                         block.setType(Material.WHEAT);
-                        if (city != null) {
-                            city.addResource(Material.WHEAT, 1);
-                        }
+                        addChestItems(Material.WHEAT, 1);
                         plugin.getLogger().info("NPC " + uuid + " harvested wheat.");
                         return;
                     }
                 }
             }
+        }
+
+        // Try to plant any available saplings on nearby dirt or grass
+        Material[] saplings = {
+            Material.OAK_SAPLING,
+            Material.BIRCH_SAPLING,
+            Material.SPRUCE_SAPLING,
+            Material.JUNGLE_SAPLING,
+            Material.ACACIA_SAPLING
+        };
+        for (int x = -radius; x <= radius; x++) {
+            for (int z = -radius; z <= radius; z++) {
+                Block soil = loc.getBlock().getRelative(x, -1, z);
+                Block above = soil.getRelative(0, 1, 0);
+                if ((soil.getType() == Material.GRASS_BLOCK || soil.getType() == Material.DIRT) && above.getType() == Material.AIR) {
+                    for (Material sap : saplings) {
+                        if (getChestItemCount(sap) > 0) {
+                            above.setType(sap);
+                            removeChestItems(sap, 1);
+                            plugin.getLogger().info("NPC " + uuid + " planted " + sap.name().toLowerCase() + ".");
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private void performCrafterTask(Villager villager) {
+        LivingPlugin plugin = LivingPlugin.getInstance();
+        if (city == null) return;
+
+        Material[] logs = {
+            Material.OAK_LOG,
+            Material.BIRCH_LOG,
+            Material.SPRUCE_LOG,
+            Material.JUNGLE_LOG,
+            Material.ACACIA_LOG
+        };
+        for (Material log : logs) {
+            if (getChestItemCount(log) > 0) {
+                removeChestItems(log, 1);
+                Material planks = Material.matchMaterial(log.name().replace("_LOG", "_PLANKS"));
+                if (planks != null) {
+                    addChestItems(planks, 4);
+                    plugin.getLogger().info("NPC " + uuid + " crafted planks from " + log.name().toLowerCase() + ".");
+                }
+                return;
+            }
+        }
+
+        if (getChestItemCount(Material.WHEAT) >= 3) {
+            removeChestItems(Material.WHEAT, 3);
+            addChestItems(Material.BREAD, 1);
+            plugin.getLogger().info("NPC " + uuid + " crafted bread.");
+            return;
+        }
+
+        if (getChestItemCount(Material.STONE) >= 4) {
+            removeChestItems(Material.STONE, 4);
+            addChestItems(Material.STONE_BRICKS, 4);
+            plugin.getLogger().info("NPC " + uuid + " crafted stone bricks.");
         }
     }
 
@@ -298,6 +358,35 @@ public class NPC {
                             }
                         }
                         chest.update();
+                    }
+                }
+            }
+        }
+    }
+
+    private void addChestItems(Material material, int amount) {
+        if (amount <= 0 || city == null) return;
+
+        LivingPlugin plugin = LivingPlugin.getInstance();
+        Location core = city.getCoreLocation();
+        if (core == null || core.getWorld() == null) return;
+
+        int radius = plugin.getConfig().getInt("storage.chest-radius", 10);
+        int remaining = amount;
+        for (int x = -radius; x <= radius && remaining > 0; x++) {
+            for (int y = -radius; y <= radius && remaining > 0; y++) {
+                for (int z = -radius; z <= radius && remaining > 0; z++) {
+                    Block block = core.getBlock().getRelative(x, y, z);
+                    if (block.getType() == Material.CHEST) {
+                        Chest chest = (Chest) block.getState();
+                        Inventory inv = chest.getBlockInventory();
+                        ItemStack toAdd = new ItemStack(material, remaining);
+                        Map<Integer, ItemStack> leftover = inv.addItem(toAdd);
+                        chest.update();
+                        if (leftover.isEmpty()) {
+                            return;
+                        }
+                        remaining = leftover.values().stream().mapToInt(ItemStack::getAmount).sum();
                     }
                 }
             }

--- a/living/src/main/resources/config.yml
+++ b/living/src/main/resources/config.yml
@@ -9,6 +9,7 @@ city:
     miner: 1              # Miner suchen nach Erzen unter der Stadt.
     farmer: 1             # Farmer kümmern sich um Felder und Lebensmittel.
     builder: 1            # Baumeister errichten neue Gebäude nach Blaupausen.
+    crafter: 1            # Handwerker verarbeiten Ressourcen zu neuen Gegenständen.
 
 storage:
   chest-radius: 10        # Radius in Blöcken um den Stadtkern, in dem Lagerkisten erkannt und genutzt werden.


### PR DESCRIPTION
## Summary
- introduce crafter job that crafts planks, bread, and stone bricks using city storage
- expand woodcutter settings to include jungle and acacia trees
- route harvested logs, ores, and crops to city chests and let farmers plant saplings

## Testing
- `./compile.sh` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (Network is unreachable))*

------
https://chatgpt.com/codex/tasks/task_e_68a4e2e33e7c8324bc03c2d7df15c8a9