### PR TITLE
Fix NPC chest inventory updates

### DIFF
--- a/living/src/main/java/com/example/living/npc/NPC.java
+++ b/living/src/main/java/com/example/living/npc/NPC.java
@@ -406,7 +406,6 @@ public class NPC {
                                 amount -= take;
                             }
                         }
-                        chest.update();
                     }
                 }
             }
@@ -431,7 +430,6 @@ public class NPC {
                         Inventory inv = chest.getBlockInventory();
                         ItemStack toAdd = new ItemStack(material, remaining);
                         Map<Integer, ItemStack> leftover = inv.addItem(toAdd);
-                        chest.update();
                         if (leftover.isEmpty()) {
                             return;
                         }


### PR DESCRIPTION
## Summary
- ensure NPC item transfers to city chests persist

## Testing
- `mvn test -e` *(fails: Could not resolve org.apache.maven.plugins:maven-resources-plugin:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a4eb6f9e8883248675ca5225e48c00